### PR TITLE
Avoid bootstrap's defaul link color

### DIFF
--- a/styles/sidebar.less
+++ b/styles/sidebar.less
@@ -13,7 +13,7 @@
 			}
 
 			a {
-				color: rgba(215, 215, 215, 0.8);
+				color: rgba(215, 215, 215, 0.8) !important;
 				text-decoration: none;
 
 				.fa {
@@ -26,13 +26,13 @@
 
 				&:hover {
 					text-decoration: none;
-					color: white;
+					color: white !important;
 				}
 			}
 
 			&.active {
 				a {
-					color: white;
+					color: white !important;
 				}
 			}
 		}


### PR DESCRIPTION
Bootstrap's blue color overwrites orion's color.